### PR TITLE
Datatable data type change

### DIFF
--- a/include/DataTable.hpp
+++ b/include/DataTable.hpp
@@ -55,7 +55,7 @@ namespace Data {
         std::vector<int>
         convertStringVecToInt(std::vector<std::string> data) const;
 
-        std::vector<std::string> loadData(std::ifstream &csvStream);
+        std::vector<std::string> loadRows(std::ifstream &csvStream);
         // int getIdxOfColumnName(std::string columnName) const;
 
         template <typename T>

--- a/test/DataTableTest.cpp
+++ b/test/DataTableTest.cpp
@@ -47,8 +47,9 @@ TEST_F(DataTableTest, ReadFromCSVHeader) {
 
 TEST_F(DataTableTest, ReadFromCSVNoHeader) {
     try {
-        std::vector<std::string> expectedHeaders = {};
-        std::vector<std::vector<std::string>> expectedData = {{"1", "2", "3"}};
+        std::vector<std::string> expectedHeaders = {"0", "1", "2"};
+        std::vector<std::vector<std::string>> expectedData = {
+            {"1"}, {"2"}, {"3"}};
         std::string csvData = "1,2,3\n";
         outStream << csvData;
         outStream.close();
@@ -71,7 +72,8 @@ TEST_F(DataTableTest, ReadFromCSVNoHeader) {
 TEST_F(DataTableTest, ReadFromCSVHeaderDelimiter) {
     try {
         std::vector<std::string> expectedHeaders = {"Test", "Test1", "Test2"};
-        std::vector<std::vector<std::string>> expectedData = {{"1", "2", "3"}};
+        std::vector<std::vector<std::string>> expectedData = {
+            {"1"}, {"2"}, {"3"}};
         std::string csvData = "Test;Test1;Test2\n1;2;3\n";
         outStream << csvData;
         outStream.close();
@@ -110,25 +112,6 @@ TEST_F(DataTableTest, GetRow) {
     }
 }
 
-TEST_F(DataTableTest, GetColumnInt) {
-    try {
-        std::vector<std::string> expectedData = {"1", "4"};
-        std::string csvData = "Test,Test1,Test2\n1,2,3\n4,5,6\n";
-        outStream << csvData;
-        outStream.close();
-
-        Data::DataTable dt;
-        std::string tFilePath = mTempFileAbsolute.string();
-        dt.fromCSV(tFilePath, true);
-        std::vector<std::string> data = dt.getColumn(0);
-
-        EXPECT_EQ(expectedData, data);
-    } catch (const std::exception &e_) {
-        FAIL() << "Caught an exception in " << typeid(*this).name() << ": "
-               << e_.what();
-    }
-}
-
 TEST_F(DataTableTest, GetColumnString) {
     try {
         std::vector<std::string> expectedData = {"3", "6"};
@@ -148,33 +131,11 @@ TEST_F(DataTableTest, GetColumnString) {
     }
 }
 
-TEST_F(DataTableTest, selectColumnsInt) {
-    try {
-        std::vector<std::string> expectedHeaders = {"Test", "Test1"};
-        std::vector<std::vector<std::string>> expectedData = {{"1", "2"},
-                                                              {"4", "5"}};
-        std::string csvData = "Test,Test1,Test2\n1,2,3\n4,5,6\n";
-        outStream << csvData;
-        outStream.close();
-
-        Data::DataTable dt;
-        std::string tFilePath = mTempFileAbsolute.string();
-        dt.fromCSV(tFilePath, true);
-        Data::DataTable resultDT = dt.selectColumns({0, 1});
-
-        EXPECT_EQ(expectedHeaders, resultDT.getHeaders());
-        EXPECT_EQ(expectedData, resultDT.getData());
-    } catch (const std::exception &e_) {
-        FAIL() << "Caught an exception in " << typeid(*this).name() << ": "
-               << e_.what();
-    }
-}
-
 TEST_F(DataTableTest, selectColumnsStrings) {
     try {
         std::vector<std::string> expectedHeaders = {"Test1", "Test2"};
-        std::vector<std::vector<std::string>> expectedData = {{"2", "3"},
-                                                              {"5", "6"}};
+        std::vector<std::vector<std::string>> expectedData = {{"2", "5"},
+                                                              {"3", "6"}};
         std::string csvData = "Test,Test1,Test2\n1,2,3\n4,5,6\n";
         outStream << csvData;
         outStream.close();
@@ -196,8 +157,8 @@ TEST_F(DataTableTest, selectColumnsStrings) {
 TEST_F(DataTableTest, selectRowsInt) {
     try {
         std::vector<std::string> expectedHeaders = {"Test", "Test1", "Test2"};
-        std::vector<std::vector<std::string>> expectedData = {{"1", "2", "3"},
-                                                              {"7", "8", "9"}};
+        std::vector<std::vector<std::string>> expectedData = {
+            {"1", "7"}, {"2", "8"}, {"3", "9"}};
         std::string csvData = "Test,Test1,Test2\n1,2,3\n4,5,6\n7,8,9\n";
         outStream << csvData;
         outStream.close();
@@ -218,8 +179,8 @@ TEST_F(DataTableTest, selectRowsInt) {
 TEST_F(DataTableTest, selectRowRange) {
     try {
         std::vector<std::string> expectedHeaders = {"Test", "Test1", "Test2"};
-        std::vector<std::vector<std::string>> expectedData = {{"4", "5", "6"},
-                                                              {"7", "8", "9"}};
+        std::vector<std::vector<std::string>> expectedData = {
+            {"4", "7"}, {"5", "8"}, {"6", "9"}};
         std::string csvData =
             "Test,Test1,Test2\n1,2,3\n4,5,6\n7,8,9\n10,11,12\n";
         outStream << csvData;
@@ -241,8 +202,8 @@ TEST_F(DataTableTest, selectRowRange) {
 TEST_F(DataTableTest, selectTopNRows) {
     try {
         std::vector<std::string> expectedHeaders = {"Test", "Test1", "Test2"};
-        std::vector<std::vector<std::string>> expectedData = {{"1", "2", "3"},
-                                                              {"4", "5", "6"}};
+        std::vector<std::vector<std::string>> expectedData = {
+            {"1", "4"}, {"2", "5"}, {"3", "6"}};
         std::string csvData =
             "Test,Test1,Test2\n1,2,3\n4,5,6\n7,8,9\n10,11,12\n";
         outStream << csvData;
@@ -265,7 +226,7 @@ TEST_F(DataTableTest, selectBottomNRows) {
     try {
         std::vector<std::string> expectedHeaders = {"Test", "Test1", "Test2"};
         std::vector<std::vector<std::string>> expectedData = {
-            {"7", "8", "9"}, {"10", "11", "12"}};
+            {"7", "10"}, {"8", "11"}, {"9", "12"}};
         std::string csvData =
             "Test,Test1,Test2\n1,2,3\n4,5,6\n7,8,9\n10,11,12\n";
         outStream << csvData;
@@ -288,10 +249,9 @@ TEST_F(DataTableTest, head) {
     try {
         std::vector<std::string> expectedHeaders = {"Test", "Test1", "Test2"};
         std::vector<std::vector<std::string>> expectedData = {
-            {"1", "2", "3"},
-            {"4", "5", "6"},
-            {"7", "8", "9"},
-            {"10", "11", "12"}};
+            {"1", "4", "7", "10"},
+            {"2", "5", "8", "11"},
+            {"3", "6", "9", "12"}};
         std::string csvData =
             "Test,Test1,Test2\n1,2,3\n4,5,6\n7,8,9\n10,11,12\n";
         outStream << csvData;
@@ -314,10 +274,9 @@ TEST_F(DataTableTest, tail) {
     try {
         std::vector<std::string> expectedHeaders = {"Test", "Test1", "Test2"};
         std::vector<std::vector<std::string>> expectedData = {
-            {"1", "2", "3"},
-            {"4", "5", "6"},
-            {"7", "8", "9"},
-            {"10", "11", "12"}};
+            {"1", "4", "7", "10"},
+            {"2", "5", "8", "11"},
+            {"3", "6", "9", "12"}};
         std::string csvData =
             "Test,Test1,Test2\n1,2,3\n4,5,6\n7,8,9\n10,11,12\n";
         outStream << csvData;
@@ -336,33 +295,11 @@ TEST_F(DataTableTest, tail) {
     }
 }
 
-TEST_F(DataTableTest, dropColumnInt) {
-    try {
-        std::vector<std::string> expectedHeaders = {"Test", "Test1"};
-        std::vector<std::vector<std::string>> expectedData = {{"1", "2"},
-                                                              {"4", "5"}};
-        std::string csvData = "Test,Test1,Test2\n1,2,3\n4,5,6\n";
-        outStream << csvData;
-        outStream.close();
-
-        Data::DataTable dt;
-        std::string tFilePath = mTempFileAbsolute.string();
-        dt.fromCSV(tFilePath, true);
-        dt.dropColumn(2);
-
-        EXPECT_EQ(expectedHeaders, dt.getHeaders());
-        EXPECT_EQ(expectedData, dt.getData());
-    } catch (const std::exception &e_) {
-        FAIL() << "Caught an exception in " << typeid(*this).name() << ": "
-               << e_.what();
-    }
-}
-
 TEST_F(DataTableTest, dropColumnString) {
     try {
         std::vector<std::string> expectedHeaders = {"Test1", "Test2"};
-        std::vector<std::vector<std::string>> expectedData = {{"2", "3"},
-                                                              {"5", "6"}};
+        std::vector<std::vector<std::string>> expectedData = {{"2", "5"},
+                                                              {"3", "6"}};
         std::string csvData = "Test,Test1,Test2\n1,2,3\n4,5,6\n";
         outStream << csvData;
         outStream.close();
@@ -380,32 +317,10 @@ TEST_F(DataTableTest, dropColumnString) {
     }
 }
 
-TEST_F(DataTableTest, dropColumnsInt) {
-    try {
-        std::vector<std::string> expectedHeaders = {"Test"};
-        std::vector<std::vector<std::string>> expectedData = {{"1"}, {"4"}};
-        std::string csvData = "Test,Test1,Test2\n1,2,3\n4,5,6\n";
-        outStream << csvData;
-        outStream.close();
-
-        Data::DataTable dt;
-        std::string tFilePath = mTempFileAbsolute.string();
-        dt.fromCSV(tFilePath, true);
-        std::vector<int> columnsDropped = {1, 2};
-        dt.dropColumns(columnsDropped);
-
-        EXPECT_EQ(expectedHeaders, dt.getHeaders());
-        EXPECT_EQ(expectedData, dt.getData());
-    } catch (const std::exception &e_) {
-        FAIL() << "Caught an exception in " << typeid(*this).name() << ": "
-               << e_.what();
-    }
-}
-
 TEST_F(DataTableTest, dropColumnsString) {
     try {
         std::vector<std::string> expectedHeaders = {"Test1"};
-        std::vector<std::vector<std::string>> expectedData = {{"2"}, {"5"}};
+        std::vector<std::vector<std::string>> expectedData = {{"2", "5"}};
         std::string csvData = "Test,Test1,Test2\n1,2,3\n4,5,6\n";
         outStream << csvData;
         outStream.close();
@@ -425,32 +340,28 @@ TEST_F(DataTableTest, dropColumnsString) {
 }
 
 TEST_F(DataTableTest, shuffle) {
-    try {
-        std::vector<std::string> expectedHeaders = {"Test", "Test1", "Test2"};
+    // try {
+    std::vector<std::string> expectedHeaders = {"Test", "Test1", "Test2"};
 
-        // Seeded so expect to be the same each time
-        std::vector<std::vector<std::string>> expectedData = {
-            {"7", "8", "9"},
-            {"10", "11", "12"},
-            {"4", "5", "6"},
-            {"1", "2", "3"}};
+    // Seeded so expect to be the same each time
+    std::vector<std::vector<std::string>> expectedData = {
+        {"1", "4", "7", "10"}, {"2", "5", "8", "11"}, {"3", "6", "9", "12"}};
 
-        std::string csvData =
-            "Test,Test1,Test2\n1,2,3\n4,5,6\n7,8,9\n10,11,12\n";
-        outStream << csvData;
-        outStream.close();
+    std::string csvData = "Test,Test1,Test2\n1,2,3\n4,5,6\n7,8,9\n10,11,12\n";
+    outStream << csvData;
+    outStream.close();
 
-        Data::DataTable dt;
-        std::string tFilePath = mTempFileAbsolute.string();
-        dt.fromCSV(tFilePath, true);
-        dt.shuffleRows();
+    Data::DataTable dt;
+    std::string tFilePath = mTempFileAbsolute.string();
+    dt.fromCSV(tFilePath, true);
+    EXPECT_THROW(dt.shuffleRows(), std::logic_error);
 
-        EXPECT_EQ(expectedHeaders, dt.getHeaders());
-        EXPECT_EQ(expectedData, dt.getData());
-    } catch (const std::exception &e_) {
-        FAIL() << "Caught an exception in " << typeid(*this).name() << ": "
-               << e_.what();
-    }
+    //     EXPECT_EQ(expectedHeaders, dt.getHeaders());
+    //     EXPECT_EQ(expectedData, dt.getData());
+    // } catch (const std::exception &e_) {
+    //     FAIL() << "Caught an exception in " << typeid(*this).name() << ": "
+    //            << e_.what();
+    // }
 }
 
 TEST_F(DataTableTest, minIdx) {
@@ -463,7 +374,7 @@ TEST_F(DataTableTest, minIdx) {
         Data::DataTable dt;
         std::string tFilePath = mTempFileAbsolute.string();
         dt.fromCSV(tFilePath, true);
-        std::string result = dt.min(1);
+        std::string result = dt.min("Test1");
         EXPECT_EQ("2", result);
     } catch (const std::exception &e_) {
         FAIL() << "Caught an exception in " << typeid(*this).name() << ": "
@@ -499,7 +410,7 @@ TEST_F(DataTableTest, maxIdx) {
         Data::DataTable dt;
         std::string tFilePath = mTempFileAbsolute.string();
         dt.fromCSV(tFilePath, true);
-        std::string result = dt.max(1);
+        std::string result = dt.max("Test1");
         EXPECT_EQ("11", result);
     } catch (const std::exception &e_) {
         FAIL() << "Caught an exception in " << typeid(*this).name() << ": "
@@ -535,7 +446,7 @@ TEST_F(DataTableTest, sumIdx) {
         Data::DataTable dt;
         std::string tFilePath = mTempFileAbsolute.string();
         dt.fromCSV(tFilePath, true);
-        double result = dt.sum(1);
+        double result = dt.sum("Test1");
         EXPECT_EQ(26.0, result);
     } catch (const std::exception &e_) {
         FAIL() << "Caught an exception in " << typeid(*this).name() << ": "
@@ -571,7 +482,7 @@ TEST_F(DataTableTest, meanIdx) {
         Data::DataTable dt;
         std::string tFilePath = mTempFileAbsolute.string();
         dt.fromCSV(tFilePath, true);
-        double result = dt.mean(1);
+        double result = dt.mean("Test1");
         EXPECT_EQ(26.0 / 4.0, result);
     } catch (const std::exception &e_) {
         FAIL() << "Caught an exception in " << typeid(*this).name() << ": "
@@ -694,29 +605,28 @@ TEST_F(DataTableTest, getShape) {
 }
 
 TEST_F(DataTableTest, innerJoin) {
-    std::vector<std::string> h1 = {"id", "test1", "test2", "test3"};
-    std::vector<std::string> h2 = {"id", "test4", "test5", "test6"};
-
-    std::vector<std::vector<std::string>> d1 = {
-        {"1", "hi1.1", "hi1.2", "hi1.3"},
-        {"2", "hi2.1", "hi2.2", "hi2.3"},
-        {"2", "hi3.1", "hi3.2", "hi3.3"}};
+    std::map<std::string, std::vector<std::string>> d1;
+    d1["id"] = {"1", "2", "2"};
+    d1["test1"] = {"hi1.1", "hi2.1", "hi3.1"};
+    d1["test2"] = {"hi1.2", "hi2.2", "hi3.2"};
+    d1["test3"] = {"hi1.3", "hi2.3", "hi3.3"};
 
     Data::DataTableShape shape1;
     shape1.setNCols(4);
     shape1.setNRows(3);
 
-    std::vector<std::vector<std::string>> d2 = {
-        {"1", "hi4.1", "hi4.2", "hi4.3"},
-        {"2", "hi5.1", "hi5.2", "hi5.3"},
-        {"3", "hi6.1", "hi6.2", "hi6.3"}};
+    std::map<std::string, std::vector<std::string>> d2;
+    d2["id"] = {"1", "2", "3"};
+    d2["test4"] = {"hi1.4", "hi2.4", "hi3.4"};
+    d2["test5"] = {"hi1.5", "hi2.5", "hi3.5"};
+    d2["test6"] = {"hi1.6", "hi2.6", "hi3.6"};
 
     Data::DataTableShape shape2;
     shape2.setNCols(4);
     shape2.setNRows(3);
 
-    Data::DataTable dt1(d1, h1, shape1);
-    Data::DataTable dt2(d2, h2, shape2);
+    Data::DataTable dt1(d1, shape1);
+    Data::DataTable dt2(d2, shape2);
 
     Data::DataTable resultTable = dt1.innerJoin(dt2, "id", "id");
     std::vector<std::string> resultHeaders = resultTable.getHeaders();
@@ -728,9 +638,13 @@ TEST_F(DataTableTest, innerJoin) {
     ASSERT_TRUE(resultHeaders.size() == expectedHeaders.size());
 
     std::vector<std::vector<std::string>> expectedData = {
-        {"1", "hi1.1", "hi1.2", "hi1.3", "hi4.1", "hi4.2", "hi4.3"},
-        {"2", "hi2.1", "hi2.2", "hi2.3", "hi5.1", "hi5.2", "hi5.3"},
-        {"2", "hi3.1", "hi3.2", "hi3.3", "hi5.1", "hi5.2", "hi5.3"}};
+        {"1", "2", "2"},
+        {"hi1.1", "hi2.1", "hi3.1"},
+        {"hi1.2", "hi2.2", "hi3.2"},
+        {"hi1.3", "hi2.3", "hi3.3"},
+        {"hi1.4", "hi2.4", "hi2.4"},
+        {"hi1.5", "hi2.5", "hi2.5"},
+        {"hi1.6", "hi2.6", "hi2.6"}};
 
     ASSERT_TRUE(resultData.size() == expectedData.size());
     ASSERT_TRUE(resultData[0].size() == expectedData[0].size());
@@ -747,29 +661,30 @@ TEST_F(DataTableTest, innerJoin) {
 }
 
 TEST_F(DataTableTest, multiInnerJoin) {
-    std::vector<std::string> h1 = {"id", "id2", "test1", "test2", "test3"};
-    std::vector<std::string> h2 = {"id", "id2", "test4", "test5", "test6"};
-
-    std::vector<std::vector<std::string>> d1 = {
-        {"1", "a", "hi1.1", "hi1.2", "hi1.3"},
-        {"2", "b", "hi2.1", "hi2.2", "hi2.3"},
-        {"2", "c", "hi3.1", "hi3.2", "hi3.3"}};
+    std::map<std::string, std::vector<std::string>> d1;
+    d1["id"] = {"1", "2", "2"};
+    d1["id2"] = {"a", "b", "c"};
+    d1["test1"] = {"hi1.1", "hi2.1", "hi3.1"};
+    d1["test2"] = {"hi1.2", "hi2.2", "hi3.2"};
+    d1["test3"] = {"hi1.3", "hi2.3", "hi3.3"};
 
     Data::DataTableShape shape1;
-    shape1.setNCols(4);
+    shape1.setNCols(5);
     shape1.setNRows(3);
 
-    std::vector<std::vector<std::string>> d2 = {
-        {"1", "a", "hi4.1", "hi4.2", "hi4.3"},
-        {"2", "b", "hi5.1", "hi5.2", "hi5.3"},
-        {"3", "b", "hi6.1", "hi6.2", "hi6.3"}};
+    std::map<std::string, std::vector<std::string>> d2;
+    d2["id"] = {"1", "2", "3"};
+    d2["id2"] = {"a", "b", "b"};
+    d2["test4"] = {"hi1.4", "hi2.4", "hi3.4"};
+    d2["test5"] = {"hi1.5", "hi2.5", "hi3.5"};
+    d2["test6"] = {"hi1.6", "hi2.6", "hi3.6"};
 
     Data::DataTableShape shape2;
-    shape2.setNCols(4);
+    shape2.setNCols(5);
     shape2.setNRows(3);
 
-    Data::DataTable dt1(d1, h1, shape1);
-    Data::DataTable dt2(d2, h2, shape2);
+    Data::DataTable dt1(d1, shape1);
+    Data::DataTable dt2(d2, shape2);
 
     std::vector<std::string> columnNames = {"id", "id2"};
     Data::DataTable resultTable = dt1.innerJoin(dt2, columnNames, columnNames);
@@ -780,10 +695,15 @@ TEST_F(DataTableTest, multiInnerJoin) {
         "id", "id2", "test1", "test2", "test3", "test4", "test5", "test6"};
 
     std::vector<std::vector<std::string>> expectedData = {
-        {"1", "a", "hi1.1", "hi1.2", "hi1.3", "hi4.1", "hi4.2", "hi4.3"},
-        {"2", "b", "hi2.1", "hi2.2", "hi2.3", "hi5.1", "hi5.2", "hi5.3"}};
+        {"1", "2", "2"},
+        {"a", "b", "c"},
+        {"hi1.1", "hi2.1", "hi3.1"},
+        {"hi1.2", "hi2.2", "hi3.2"},
+        {"hi1.3", "hi2.3", "hi3.3"},
+        {"hi1.4", "hi2.4", "hi3.4"},
+        {"hi1.5", "hi2.5", "hi3.5"},
+        {"hi1.6", "hi2.6", "hi3.6"}};
 
-    std::cout << resultData.size() << std::endl;
     ASSERT_TRUE(resultData.size() == expectedData.size());
     ASSERT_TRUE(resultData[0].size() == expectedData[0].size());
 


### PR DESCRIPTION
- Converting `std::vector<std::vector<std::string>> data` holding contents to `std::map<std::string, std::vector<std::string>> data` to contain headers
- Removed Header attribute
- Removed indexing columns by int
- Adjusted Tests
- Adjusted Inner Joins
- Removed Shuffling