### PR TITLE
Adding GetSectionCategories to Configuration

### DIFF
--- a/.github/workflows/unit_testing.yml
+++ b/.github/workflows/unit_testing.yml
@@ -69,7 +69,7 @@ jobs:
       uses: msys2/setup-msys2@v2
 
     - name: Install GTest Windows
-      run: msys2 -c 'pacman -S mingw-w64-x86_64-gtest'
+      run: msys2 -c 'yes | pacman -S mingw-w64-x86_64-gtest'
 
     - name: Configure CMake
       # Configure CMake in a 'build' subdirectory. `CMAKE_BUILD_TYPE` is only required if you are using a single-configuration generator such as make.

--- a/include/Configuration.hpp
+++ b/include/Configuration.hpp
@@ -28,6 +28,8 @@ namespace Data {
         virtual std::vector<int> parseString2VectorOfInts(std::string st) = 0;
         virtual std::vector<std::string> getStringVector(std::string str) = 0;
         virtual std::vector<int> getIntVector(std::string str) = 0;
+        virtual std::vector<std::string>
+        getSectionCategories(std::string section) = 0;
     };
 
     using IConfigurationPtr = std::shared_ptr<Data::IConfiguration>;
@@ -117,6 +119,9 @@ namespace Data {
                 return {};
             }
         }
+
+        std::vector<std::string>
+        getSectionCategories(std::string section) override;
     };
 } // namespace Data
 #endif

--- a/include/DataManagement.hpp
+++ b/include/DataManagement.hpp
@@ -4,7 +4,7 @@
 #include "Configuration.hpp"
 #include "DataTable.hpp"
 #include "Reader.hpp"
-#include "SQLite3.hpp"
+// #include "SQLite3.hpp"
 #include "Writer.hpp"
 
 #endif

--- a/src/Configuration.cpp
+++ b/src/Configuration.cpp
@@ -94,4 +94,16 @@ namespace Data {
         }
         return result;
     }
+
+    std::vector<std::string>
+    Configuration::getSectionCategories(std::string section) {
+        boost::property_tree::ptree subTree =
+            this->dmTree->ptree.get_child(section);
+        std::vector<std::string> keyList;
+
+        for (auto &key : subTree) {
+            keyList.push_back(key.first);
+        }
+        return keyList;
+    }
 } // namespace Data

--- a/test.sh
+++ b/test.sh
@@ -1,0 +1,4 @@
+rm -rf build/*
+cmake -S . -B build -DBUILD_SHARED_LIBS=YES -DCMAKE_BUILD_TYPE=Debug -DBUILD_DATA_TESTS=ON
+cmake --build build
+./build/test/dataTests

--- a/test/ConfigurationTest.cpp
+++ b/test/ConfigurationTest.cpp
@@ -90,3 +90,11 @@ TEST_F(ConfigurationTest, GetNoVector) {
     std::vector<int> expected = {};
     EXPECT_EQ(expected, config.getIntVector("section.vector"));
 }
+
+TEST_F(ConfigurationTest, GetSectionCategories) {
+    outStream << "[section]\nvector = foo, bar, baz\nvectortwo = aaa, bbb, ccc"
+              << std::endl;
+    Data::Configuration config(tempFilePath.string());
+    std::vector<std::string> expected = {"vector", "vectortwo"};
+    EXPECT_EQ(expected, config.getSectionCategories("section"));
+}


### PR DESCRIPTION
Adding a method to Configuration to get the Section from the configuration file and return a vector of strings containing each key in the section.
Note: I did update the CI windows pipeline again but I don't intend to try to figure it out right now if it still doesn't work. I don't have the energy for that today.