### PR TITLE
Fix MacOS Release Build Stream

### DIFF
--- a/.github/workflows/build_release.yml
+++ b/.github/workflows/build_release.yml
@@ -1,6 +1,9 @@
 name: Build and Upload Release
 
 on:
+    workflow_dispatch:
+        branches: 
+            - main
     release:
         types: [published]
 


### PR DESCRIPTION
- Remove explicit definition of the operating system version
- Enable manual workflow trigger