### PR TITLE
Reintroduce shared library build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,9 +1,9 @@
 cmake_minimum_required(VERSION 3.23)
 
 project(
-    DataManagement
-    VERSION 1.0.0
-    DESCRIPTION "A Data Management Library Used By Syndemics Lab Simulation Models"
+  DataManagement
+  VERSION 1.0.0
+  DESCRIPTION "A Data Management Library Used By Syndemics Lab Simulation Models"
 )
 
 set(CMAKE_CXX_STANDARD 17)
@@ -14,81 +14,137 @@ set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/../bin)
 
 option(BUILD_TESTS "enable Data tests" OFF)
 if(BUILD_TESTS STREQUAL ON)
-    add_subdirectory(test)
+  add_subdirectory(test)
 endif()
 
 option(BUILD_STATIC_LIBRARY "build static library" ON)
 if(BUILD_STATIC_LIBRARY STREQUAL ON)
-    set(LIB_TYPE STATIC)
-else()
-    set(LIB_TYPE SHARED)
-endif()
-
-add_library(${PROJECT_NAME} ${LIB_TYPE}
-)
-
-find_package(Boost CONFIG REQUIRED COMPONENTS filesystem)
-
-set(PRIVATE_SOURCE_LIST
+  add_library(${PROJECT_NAME} STATIC)
+  set(PRIVATE_SOURCE_LIST
     ${PROJECT_SOURCE_DIR}/src/DataTable.cpp
     ${PROJECT_SOURCE_DIR}/src/Configuration.cpp
-)
+  )
 
-set(PUBLIC_HEADER_LIST
+  set(PUBLIC_HEADER_LIST
     ${PROJECT_SOURCE_DIR}/include/Configuration.hpp
     ${PROJECT_SOURCE_DIR}/include/DataManagement.hpp
     ${PROJECT_SOURCE_DIR}/include/DataTable.hpp
     ${PROJECT_SOURCE_DIR}/include/Reader.hpp
     ${PROJECT_SOURCE_DIR}/include/Writer.hpp
-)
+  )
 
-target_sources(${PROJECT_NAME}
+  target_sources(${PROJECT_NAME}
     PUBLIC
-        FILE_SET headers TYPE HEADERS FILES ${PUBLIC_HEADER_LIST}
+    FILE_SET headers TYPE HEADERS FILES ${PUBLIC_HEADER_LIST}
     PRIVATE
-        ${PRIVATE_SOURCE_LIST}
-)
+    ${PRIVATE_SOURCE_LIST}
+  )
 
-# target_sources(${PROJECT_NAME} PUBLIC FILE_SET headers TYPE HEADERS)
+  # target_sources(${PROJECT_NAME} PUBLIC FILE_SET headers TYPE HEADERS)
 
-source_group(TREE ${CMAKE_CURRENT_SOURCE_DIR} PREFIX Sources FILES ${PRIVATE_SOURCE_LIST})
-source_group(TREE ${PROJECT_SOURCE_DIR}/include/ PREFIX Interface FILES ${PUBLIC_HEADER_LIST})
+  source_group(TREE ${CMAKE_CURRENT_SOURCE_DIR} PREFIX Sources FILES ${PRIVATE_SOURCE_LIST})
+  source_group(TREE ${PROJECT_SOURCE_DIR}/include/ PREFIX Interface FILES ${PUBLIC_HEADER_LIST})
 
-##################################################################################
+  ##################################################################################
 
-# CMake will install by default the files C:/Program Files/MyLibrary,
-# but we don't want pollute C:/Program Files, so we'll put the files
-# somewhere in the project folders.
-if(DEFINED CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT)
+  # CMake will install by default the files C:/Program Files/MyLibrary,
+  # but we don't want pollute C:/Program Files, so we'll put the files
+  # somewhere in the project folders.
+  if(DEFINED CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT)
     message(
-        STATUS
-        "CMAKE_INSTALL_PREFIX is not set\n"
-        "Default value: ${CMAKE_INSTALL_PREFIX}\n"
-        "Will set it to ${CMAKE_SOURCE_DIR}/install"
+      STATUS
+      "CMAKE_INSTALL_PREFIX is not set\n"
+      "Default value: ${CMAKE_INSTALL_PREFIX}\n"
+      "Will set it to ${CMAKE_SOURCE_DIR}/install"
     )
     set(CMAKE_INSTALL_PREFIX
-        "${CMAKE_SOURCE_DIR}/../RESPONDSimulationv2/lib/dminstall"
-        CACHE PATH "Where the library will be installed to" FORCE
+      "${CMAKE_SOURCE_DIR}/../RESPONDSimulationv2/lib/dminstall"
+      CACHE PATH "Where the library will be installed to" FORCE
     )
-else()
+  else()
     message(
-        STATUS
-        "CMAKE_INSTALL_PREFIX was already set\n"
-        "Current value: ${CMAKE_INSTALL_PREFIX}"
+      STATUS
+      "CMAKE_INSTALL_PREFIX was already set\n"
+      "Current value: ${CMAKE_INSTALL_PREFIX}"
     )
+  endif()
+
+  include(GNUInstallDirs)  # for CMAKE_INSTALL_INCLUDEDIR definition
+  set(CMAKE_INSTALL_INCLUDEDIR "${CMAKE_INSTALL_PREFIX}")
+
+  target_include_directories(${PROJECT_NAME}
+    PUBLIC
+    $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include>
+    $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
+    PRIVATE
+    ${CMAKE_CURRENT_LIST_DIR}
+  )
+else()
+  add_library(${PROJECT_NAME} SHARED
+    "src/DataTable.cpp"
+    "src/Configuration.cpp"
+  )
+  target_include_directories(
+    ${PROJECT_NAME}
+    PUBLIC
+    "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>"
+    "$<INSTALL_INTERFACE:include>"
+  )
+  install(
+    TARGETS ${PROJECT_NAME}
+    EXPORT DataManagementTargets
+    LIBRARY DESTINATION lib
+    ARCHIVE DESTINATION lib
+    RUNTIME DESTINATION bin
+    INCLUDES DESTINATION include
+  )
+
+  install(
+    FILES
+    "include/Configuration.hpp"
+    "include/DataManagement.hpp"
+    "include/DataTable.hpp"
+    "include/Reader.hpp"
+    "include/Writer.hpp"
+    DESTINATION include
+  )
+
+  install(
+    EXPORT DataManagementTargets
+    FILE DataManagementTargets.cmake
+    NAMESPACE DataManagement::
+    DESTINATION lib/cmake/DataManagement
+  )
+
+  include(CMakePackageConfigHelpers)
+
+  configure_package_config_file(
+    ${CMAKE_CURRENT_SOURCE_DIR}/Config.cmake.in
+    "${CMAKE_CURRENT_BINARY_DIR}/DataManagementConfig.cmake"
+    INSTALL_DESTINATION lib/cmake/DataManagement
+  )
+
+  install(
+    FILES
+    "${CMAKE_CURRENT_BINARY_DIR}/DataManagementConfig.cmake"
+    "${CMAKE_CURRENT_BINARY_DIR}/DataManagementConfigVersion.cmake"
+    DESTINATION lib/cmake/DataManagement
+  )
+
+  set(version 1.0.0)
+  set_property(TARGET ${PROJECT_NAME} PROPERTY VERSION ${version})
+  set_property(TARGET ${PROJECT_NAME} PROPERTY SOVERSION 1)
+  set_property(TARGET ${PROJECT_NAME} PROPERTY INTERFACE_DataManagement_MAJOR_VERSION 1)
+  set_property(TARGET ${PROJECT_NAME} APPEND PROPERTY COMPATIBLE_INTERFACE_STRING DataManagement_MAJOR_VERISON)
+
+  write_basic_package_version_file(
+    "${CMAKE_CURRENT_BINARY_DIR}/DataManagementConfigVersion.cmake"
+    VERSION "${version}"
+    COMPATIBILITY AnyNewerVersion
+  )
 endif()
 
-include(GNUInstallDirs)  # for CMAKE_INSTALL_INCLUDEDIR definition
-set(CMAKE_INSTALL_INCLUDEDIR "${CMAKE_INSTALL_PREFIX}")
 
-target_include_directories(${PROJECT_NAME}
-    PUBLIC
-        $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include>
-        $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
-    PRIVATE
-        ${CMAKE_CURRENT_LIST_DIR}
-        ${Boost_INCLUDE_DIRS}
-        )
 
 
 # To install the public header files, we cannot just set the PUBLIC_HEADER property on these

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,4 @@
 cmake_minimum_required(VERSION 3.23)
-cmake_policy(SET CMP0144 NEW)
 
 project(
     DataManagement
@@ -28,7 +27,6 @@ endif()
 add_library(${PROJECT_NAME} ${LIB_TYPE}
 )
 
-# set(BOOST_ROOT "$ENV{BOOST_ROOT}")
 find_package(Boost CONFIG REQUIRED COMPONENTS filesystem)
 
 set(PRIVATE_SOURCE_LIST

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ Homepage = "https://github.com/SyndemicsLab/DataManagement"
 Issues = "https://github.com/SyndemicsLab/DataManagement/issues"
 
 [tool.scikit-build]
-cmake.version = ">=3.15"
+cmake.version = ">=3.27"
 
 [tool.scikit-build.cmake.define]
 BUILD_SHARED_LIBS = "YES"

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -23,11 +23,19 @@ showhelp () {
     echo "n              Build Benchmarking executable"
 }
 
+# red output
+RED='\033[0;31m'
+# no color
+NC='\033[0m'
+
+err () {
+    echo -e "$RED$1$NC"
+}
+
 # set default build type
 BUILDTYPE="Release"
 BUILD_TESTS=""
 BUILD_BENCHMARK=""
-BUILD_SHARED_LIBRARY=""
 BUILD_STATIC_LIBRARY="ON"
 
 # process optional command line flags
@@ -52,14 +60,13 @@ while getopts ":hnptl:" option; do
             BUILD_TESTS="ON"
             ;;
         l)
-            BUILD_SHARED_LIBRARY="ON"
             BUILD_STATIC_LIBRARY="OFF"
             ;;
         n)
             BUILD_BENCHMARK="ON"
             ;;
         \?)
-            echo "Error: Invalid option flag provided!"
+            err "Error: Invalid option flag provided!"
             showhelp
             exit
             ;;
@@ -85,21 +92,17 @@ done
         if [[ -n "$BUILD_BENCHMARK" ]]; then
             CMAKE_COMMAND="$CMAKE_COMMAND -DBUILD_BENCHMARK=$BUILD_BENCHMARK"
         fi
-        # build static libraries
-        if [[ -n "$BUILD_STATIC_LIBRARY" ]]; then
-            CMAKE_COMMAND="$CMAKE_COMMAND -DBUILD_STATIC_LIBRARY=$BUILD_STATIC_LIBRARY"
-        fi
-        # build shared libraries
-        if [[ -n "$BUILD_SHARED_LIBRARY" ]]; then
-            CMAKE_COMMAND="$CMAKE_COMMAND -DBUILD_SHARED_LIBRARY=$BUILD_SHARED_LIBRARY"
-        fi
+	# build static library if BUILD_STATIC_LIBRARY is on, otherwise build
+	# shared library
+        CMAKE_COMMAND="$CMAKE_COMMAND -DBUILD_STATIC_LIBRARY=$BUILD_STATIC_LIBRARY"
 
+	err "[EXECUTE] $CMAKE_COMMAND"
         # run the full build command as specified
 	$CMAKE_COMMAND
 	# catch the error if build fails
 	ERROR_CODE="$?"
         if [[ "$ERROR_CODE" -ne "0" ]]; then
-	    echo "Build failed. Exiting with error code $ERROR_CODE..."
+	    err "Build failed. Exiting with error code $ERROR_CODE..."
 	    exit "$ERROR_CODE"
 	fi
         (

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -39,7 +39,7 @@ BUILD_BENCHMARK=""
 BUILD_STATIC_LIBRARY="ON"
 
 # process optional command line flags
-while getopts ":hnptl:" option; do
+while getopts ":lhnpt:" option; do
     case $option in
         h)
             showhelp


### PR DESCRIPTION
- Bumps required CMake version to `>=3.27`
- Adds color to warning/error output in `build.sh`
- Per title, adds shared library (`lib/libDataManagement.so`) build back to `DataManagement`